### PR TITLE
Return null on unsupported history requests

### DIFF
--- a/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDataDownloader.cs
+++ b/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDataDownloader.cs
@@ -86,6 +86,11 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
 
             var data = _brokerage.GetHistory(historyRequest);
 
+            if (data == null)
+            {
+                return Enumerable.Empty<BaseData>();
+            }
+
             return data;
 
         }
@@ -110,7 +115,7 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
                 throw new Exception($"Unknown ticker symbol: {ticker}");
             }
         }
-        
+
         #region Console Helper
 
         /// <summary>

--- a/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDataDownloader.cs
+++ b/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDataDownloader.cs
@@ -86,11 +86,6 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
 
             var data = _brokerage.GetHistory(historyRequest);
 
-            if (data == null)
-            {
-                return Enumerable.Empty<BaseData>();
-            }
-
             return data;
 
         }

--- a/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDataDownloader.cs
+++ b/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDataDownloader.cs
@@ -54,21 +54,6 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
             var resolution = dataDownloaderGetParameters.Resolution;
             var startUtc = dataDownloaderGetParameters.StartUtc;
             var endUtc = dataDownloaderGetParameters.EndUtc;
-            var tickType = dataDownloaderGetParameters.TickType;
-
-            if (tickType != TickType.Trade)
-            {
-                return Enumerable.Empty<BaseData>();
-            }
-
-            if (resolution == Resolution.Tick || resolution == Resolution.Second)
-                throw new ArgumentException($"Resolution not available: {resolution}");
-
-            if (!_symbolMapper.IsKnownLeanSymbol(symbol))
-                throw new ArgumentException($"The ticker {symbol.Value} is not available.");
-
-            if (endUtc < startUtc)
-                throw new ArgumentException("The end date must be greater or equal than the start date.");
 
             var historyRequest = new HistoryRequest(
                 startUtc,
@@ -87,7 +72,6 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
             var data = _brokerage.GetHistory(historyRequest);
 
             return data;
-
         }
 
         /// <summary>

--- a/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDownloaderProgram.cs
+++ b/QuantConnect.BitfinexBrokerage.ToolBox/BitfinexDownloaderProgram.cs
@@ -55,6 +55,10 @@ namespace QuantConnect.ToolBox.BitfinexDownloader
                         foreach (var castResolution in resolutions)
                         {
                             var data = downloader.Get(new DataDownloaderGetParameters(symbol, castResolution, fromDate, toDate));
+                            if (data == null)
+                            {
+                                continue;
+                            }
 
                             // Save the data (single resolution)
                             var writer = new LeanDataWriter(castResolution, symbol, dataDirectory);


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

#### Description
<!--- Describe your changes in detail -->

Returning null on unsupported history requests instead of returning an empty enumerable. This allows to differentiate empty results from unsupported cases.

#### Related Issue
<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

N/A

#### Motivation and Context
<!--- Why is this change required? What problem does it solve? -->

N/A

#### Requires Documentation Change
<!--- Please indicate if these changes will require updates to documentation, and if so, specify what changes are required -->

N/A

#### How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

Unit tests

#### Types of changes
<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] Refactor (non-breaking change which improves implementation)
- [ ] Performance (non-breaking change which improves performance. Please add associated performance test and results)
- [x] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)
- [ ] Non-functional change (xml comments/documentation/etc)

#### Checklist:
<!--- The following is a checklist of items that MUST be completed before a PR is accepted -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
- [x] My code follows the code style of this project.
- [x] I have read the **CONTRIBUTING** [document](https://github.com/QuantConnect/Lean/blob/master/CONTRIBUTING.md).
- [x] I have added tests to cover my changes. <!--- If not applicable, please explain why -->
- [x] All new and existing tests passed.
- [x] My branch follows the naming convention `bug-<issue#>-<description>` or `feature-<issue#>-<description>`

<!--- Template inspired by https://www.talater.com/open-source-templates/#/page/99 -->
